### PR TITLE
Escapes special chars in search box (not in extended search)

### DIFF
--- a/ting_search.module
+++ b/ting_search.module
@@ -704,6 +704,7 @@ function ting_search_submit($form, &$form_state) {
 
   $form_id = $form['form_id']['#value']; // 'search_block_form'
   $keys = $form_state['values'][$form_id];
+  $keys = str_replace(array('(', ')', '[', ']'), array('\(', '\)', '\[', '\]'), $keys);
   $fields = array();
 
   $extended_fields = array(


### PR DESCRIPTION
Escapes special chars in search box (not in extended search) because search_autocomplete finds results thats not showing up in the search result. For Example: deftones (chino moreno, abe cunningham, chi cheng, frank delgado, stephen carpenter) ... [et al.]