### PR TITLE
Fix (functional) typo in commit 3b60ea443a9efd1725e2960cf299fe63a978ec1f...

### DIFF
--- a/ting_search.module
+++ b/ting_search.module
@@ -36,7 +36,7 @@ function ting_search_menu_alter(&$items) {
   $items['search/node/%menu_tail']['load arguments'] = array('%map', '%index');
   $items['search/ting']['title'] = 'Brønd';
   $items['search/ting/%menu_tail']['title'] = 'Brønd';
-  $items['search/meta/%menu_tail']['load arguments'] = array('%map', '%index');
+  $items['search/ting/%menu_tail']['load arguments'] = array('%map', '%index');
   $items['search/meta']['title'] = 'Universal Search';
   $items['search/meta/%menu_tail']['title'] = 'Universal Search';
   $items['search/meta/%menu_tail']['load arguments'] = array('%map', '%index');


### PR DESCRIPTION
....

According to the mentioned commit, this is supposed to remove some warning.
However, I haven't seen the warning. So maybe these could be removed instead.